### PR TITLE
Master

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,11 +94,13 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
           var version =  chunk.keyCommit.version;
 
           var prerelease = semver.parse(version).prerelease.length > 0;
+          
+          var repoUrl = context.repository.replace(/^(?:http:\/\/|www\.|https:\/\/)([^\/]+\/)/, "");
 
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable
             owner: context.owner,
-            repo: context.repository,
+            repo: repoUrl,
             tag_name: version,
             body: chunk.log,
             prerelease: prerelease

--- a/index.js
+++ b/index.js
@@ -94,13 +94,11 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
           var version =  chunk.keyCommit.version;
 
           var prerelease = semver.parse(version).prerelease.length > 0;
-          
-          var repoUrl = context.repository.replace(/^(?:http:\/\/|www\.|https:\/\/)([^\/]+\/)/, "");
 
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable
             owner: context.owner,
-            repo: repoUrl,
+            repo: context.repository,
             tag_name: version,
             body: chunk.log,
             prerelease: prerelease

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable
             owner: context.owner,
-            repo: context.repository.replace(/^(?:http:\/\/|www\.|https:\/\/)([^\/]+\/)/, ''),
+            repo: context.repository,
             tag_name: version,
             body: chunk.log,
             prerelease: prerelease

--- a/index.js
+++ b/index.js
@@ -95,12 +95,10 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
 
           var prerelease = semver.parse(version).prerelease.length > 0;
 
-          var repoUrl = context.repository.replace(/^(?:http:\/\/|www\.|https:\/\/)([^\/]+\/)/, '');
-
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable
             owner: context.owner,
-            repo: repoUrl,
+            repo: context.repository.replace(/^(?:http:\/\/|www\.|https:\/\/)([^\/]+\/)/, ''),
             tag_name: version,
             body: chunk.log,
             prerelease: prerelease

--- a/index.js
+++ b/index.js
@@ -95,10 +95,12 @@ function conventionalGithubReleaser(auth, changelogOpts, context, gitRawCommitsO
 
           var prerelease = semver.parse(version).prerelease.length > 0;
 
+          var repoUrl = context.repository.replace(/^(?:http:\/\/|www\.|https:\/\/)([^\/]+\/)/, '');
+
           var promise = Q.nfcall(github.releases.createRelease, {
             // jscs:disable
             owner: context.owner,
-            repo: context.repository,
+            repo: repoUrl,
             tag_name: version,
             body: chunk.log,
             prerelease: prerelease

--- a/test/fixtures/_package.json
+++ b/test/fixtures/_package.json
@@ -1,5 +1,5 @@
 {
   "name": "conventional-github-releaser-test",
   "version": "0.0.0",
-  "repository": "https://github.com/fusionstrings/conventional-github-releaser-test"
+  "repository": "stevemaotest/conventional-github-releaser-test"
 }

--- a/test/fixtures/_package.json
+++ b/test/fixtures/_package.json
@@ -1,5 +1,5 @@
 {
   "name": "conventional-github-releaser-test",
   "version": "0.0.0",
-  "repository": "stevemaotest/conventional-github-releaser-test"
+  "repository": "https://github.com/fusionstrings/conventional-github-releaser-test"
 }


### PR DESCRIPTION
fix issue where if repository field is fully qualified URL ie. `https://github.com/username/repository` in `package.json`, instead of shorthand `username/repository`, release generation silently fails.